### PR TITLE
miscellaneous bugfixes

### DIFF
--- a/gerrit_hooks/containers.py
+++ b/gerrit_hooks/containers.py
@@ -69,8 +69,8 @@ class HookFlagDefinitions:
                           "--commit <commit> --comment <comment> " \
                           "--Code-Review <score> " \
                           "--Verified <score> " \
-                          "--Code-Review-oldValue <score>" \
-                          "--Verified-oldValue <score>"
+                          "--Code-Review-oldValue <score> " \
+                          "--Verified-oldValue <score> "
 
     CHANGE_MERGED_FLAGS = "--change <change id> --change-url <change url> " \
                           "--change-owner <change owner> --change-owner-username <username> " \
@@ -157,7 +157,8 @@ class HookFlagDefinitions:
 
         :param str label: The label of the approva_category to add.
         """
-        cls.COMMENT_ADDED_FLAGS += "--{} <score> --{}-oldValue <score>"
+        cls.COMMENT_ADDED_FLAGS += "--{} <score> --{}-oldValue <score>".format(label, label)
+        cls.__mapping__[SupportedHooks.COMMENT_ADDED] = cls.COMMENT_ADDED_FLAGS
 
     def __getitem__(self, item):
         """Return the flags for the given hook name as a dict.
@@ -169,7 +170,7 @@ class HookFlagDefinitions:
         flag_string = self.__mapping__[item]
         flag_configuration = {}
         for match in self.FLAG_PATTERN.finditer(flag_string):
-            flag, description = match.flag, match.description
+            flag, description = match.group('flag'), match.group('description')
             options = {}
             if (flag in ('--hashtag', '--added', '--removed')
                     and item == SupportedHooks.HASHTAGS_CHANGED):
@@ -188,6 +189,6 @@ class HookFlagDefinitions:
                 options.update({'nargs': '1', 'action': 'append'})
             flag_configuration[flag] = description, options
         return {
-            match.flag: (match.description, {})
+            match.group('flag'): (match.group('description'), {})
             for match in self.FLAG_PATTERN.finditer(flag_string)
         }

--- a/gerrit_hooks/hook.py
+++ b/gerrit_hooks/hook.py
@@ -21,8 +21,10 @@ def _generate_parser(**cli_kwargs):
     :rtype: argparse.ArgumentParser
     """
     parser = argparse.ArgumentParser()
-    for flag, description, options in cli_kwargs.items():
-        parser.add_argument(flag, description=description, required=False, **options)
+    for flag, details in cli_kwargs.items():
+        description = details[0]
+        options = details[1]
+        parser.add_argument(flag, help=description, required=False, **options)
     return parser
 
 


### PR DESCRIPTION
- missing spaces when adding "...-oldValue" flags in containers.py, meaning that parser in later stages doesn't work
- when `cls.COMMENT_ADDED_FLAGS` gets updated, we need to update `__mapping__` otherwise it will have the value from initialization when `__getitem__` is called later on
- referencing named matches as if they were attributes of the `re.Match` object (must be accessed with `.group()` function)
- in `hook.py`: tried to take result from `HookFlagDefinitions.__getitem__` as if it was a 3 tuple, but it's actually a dictionary with values that are 2-tuples. Updated code in `_generate_parser` to reflect that

In this way I'm able to run

```
import gerrit_hooks

gerrit_hooks.add_custom_approval_category('Self-Review')
# Note: because of how I'm using this, I can't rely on __file__
gerrit_parser = gerrit_hooks.build_parser_for('comment-added')
# By calling build_parser_for() manually, the user could later call parse_known_args, or even
# add some custom arguments depending on their use case
gerrit_args = gerrit_parser.parse_args()
```

And get the expected result (instead of exceptions)